### PR TITLE
New sensor: Canon - C300 Mark II

### DIFF
--- a/sensors.json
+++ b/sensors.json
@@ -38,5 +38,25 @@
         }
       }
     }
+  },
+  "Canon": {
+    "C300 Mark II": {
+      "All": {
+        "resolution": {
+          "width": 4096.0,
+          "height": 2160.0
+        },
+        "mm": {
+          "width": 24.6,
+          "height": 13.8,
+          "diagonal": 28.206
+        },
+        "inches": {
+          "width": 0.969,
+          "height": 0.543,
+          "diagonal": 1.111
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
This pull request adds new sensor data for the camera C300 Mark II by Canon.

Closes #54

### References

Here is some good information.
https://duckduckgo.com/?q=information&t=newext&atb=v281-1
More on this line!


### Vendor

Canon

### Custom Vendor

_No response_

### Camera

C300 Mark II

### Additional Information

_No response_

### Name

All

### Focal Length

_No response_

### Resolution

4096 x 2160

### Sensor size (mm)

24.6 x 13.8mm

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_