### PR TITLE
New sensor: ARRI - ALEXA Mini

### DIFF
--- a/sensors.json
+++ b/sensors.json
@@ -36,6 +36,22 @@
           "height": 0.697,
           "diagonal": 1.0846
         }
+      },
+      "3.4K Open Gate": {
+        "resolution": {
+          "width": 3424.0,
+          "height": 2202.0
+        },
+        "mm": {
+          "width": 28.25,
+          "height": 18.17,
+          "diagonal": 33.589
+        },
+        "inches": {
+          "width": 1.112,
+          "height": 0.715,
+          "diagonal": 1.322
+        }
       }
     }
   }


### PR DESCRIPTION
This pull request adds new sensor data for the camera ALEXA Mini by ARRI.

Closes #56

### References

-

### Vendor

ARRI

### Other Vendor

_No response_

### Camera

ALEXA Mini

### Additional Information

_No response_

### Name

3.4K Open Gate

### Focal Length

_No response_

### Resolution

3424 x 2202 

### Sensor size (mm)

28.25 mm x 18.17

### Sensor size (inches)

1.112 in x 0.715

### Name

3.2K

### Focal Length

_No response_

### Resolution

3200 x 1800

### Sensor size (mm)

26.40 mm x 14.85

### Sensor size (inches)

1.039 in x 0.585

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_