### PR TITLE
New sensor: ARRI - ALEXA Mini

### DIFF
--- a/sensors.json
+++ b/sensors.json
@@ -36,6 +36,22 @@
           "height": 0.697,
           "diagonal": 1.0846
         }
+      },
+      "2.8K 4:3": {
+        "resolution": {
+          "width": 2880.0,
+          "height": 2160.0
+        },
+        "mm": {
+          "width": 23.76,
+          "height": 17.82,
+          "diagonal": 29.7
+        },
+        "inches": {
+          "width": 0.935,
+          "height": 0.702,
+          "diagonal": 1.169
+        }
       }
     }
   }


### PR DESCRIPTION
This pull request adds new sensor data for the camera ALEXA Mini by ARRI.

Closes #58

### References

-

### Vendor

ARRI

### Other Vendor

_No response_

### Camera

ALEXA Mini

### Additional Information

_No response_

### Name

2.8K 4:3  

### Focal Length

_No response_

### Resolution

2880 x 2160

### Sensor size (mm)

23.76 mm x 17.82 

### Sensor size (inches)

0.935 in x 0.702

### Name

   2.8K   

### Focal Length

_No response_

### Resolution

2880 x 1620    

### Sensor size (mm)

23.76 mm x 13.37

### Sensor size (inches)

 (0.935 in x 0.526 in)

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_

### Name

_No response_

### Focal Length

_No response_

### Resolution

_No response_

### Sensor size (mm)

_No response_

### Sensor size (inches)

_No response_